### PR TITLE
Revert "fix(deps): update agp to v8.10.0"

### DIFF
--- a/AndroidApp/gradle/libs.versions.toml
+++ b/AndroidApp/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.0"
+agp = "8.9.1"
 kotlin = "2.1.20"
 com-google-devtools-ksp = "2.1.20-2.0.1" # Kotlinのバージョンに合わせる必要がある
 com-jaredsburrows-license = "0.9.8"


### PR DESCRIPTION
Reverts ptkNktq/AndroidNotificationNotifier#256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Android Gradle Plugin（AGP）のバージョンを8.10.0から8.9.1にダウングレードしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->